### PR TITLE
Add ability to get random word

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ myTrie.getPrefix('c'); // ['cat', 'cats']
 myTrie.getPrefix('c', false); // ['cat', 'cats']
 ```
 
+```javascript
+// get a random word at a prefix
+myTrie.getRandomWordWithPrefix('c'); // 'cat'
+myTrie.getRandomWordWithPrefix('c'); // 'cats'
+```
+
 Other:
 
 ```javascript

--- a/__tests__/getPrefix.js
+++ b/__tests__/getPrefix.js
@@ -33,5 +33,6 @@ test('Counting prefixes', () => {
   expect(() => input.countPrefix()).toThrow();
   expect(input.countPrefix('a')).toEqual(5);
   expect(input.countPrefix('ba')).toEqual(2);
+  expect(input.countPrefix('baal')).toEqual(1);
   expect(input.countPrefix('dog')).toEqual(0);
 });

--- a/__tests__/getPrefix.js
+++ b/__tests__/getPrefix.js
@@ -1,10 +1,15 @@
 import trie from '../src/index';
 
-const input = trie(['aah', 'aahs', 'aardvark', 'aalii', 'aal', 'baa', 'baal']);
+const words = ['aah', 'aahs', 'aardvark', 'aalii', 'aal', 'baa', 'baal'];
+const input = trie(words);
 
 describe('Getting prefixes', () => {
   it('throws an error when the first parameter is not a string', () => {
     expect(() => input.getPrefix()).toThrow();
+  });
+
+  it('returns all words with a zero-length prefix', () => {
+    expect(input.getPrefix('').length).toEqual(words.length);
   });
 
   it('errors when the sort parameter is not boolean', () => {

--- a/__tests__/getRandomWordWithPrefix.js
+++ b/__tests__/getRandomWordWithPrefix.js
@@ -1,0 +1,28 @@
+import trie from '../src/index';
+
+describe('Retrieving a random words in the trie', () => {
+  const words = ['cat', 'catfish', 'dog'];
+  const t = trie(words);
+
+  it('picks words only with the prefix', () => {
+    for(let i = 0; i < 100; i++) {
+      const word = t.getRandomWordWithPrefix('cat');
+      expect(words).toContain(word);
+      expect(word).not.toEqual('dog');
+    }
+  });
+
+  it('can pick randomly in all of the words', () => {
+    const word = t.getRandomWordWithPrefix('');
+    expect(words).toContain(word);
+  });
+
+  it('doesn\'t return words without the prefix', () => {
+    const word = t.getRandomWordWithPrefix('xyz');
+    expect(word).toEqual('');
+  });
+
+  it('errors when the prefix is not boolean', () => {
+    expect(() => t.getRandomWordWithPrefix(123)).toThrow();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -97,12 +97,9 @@ export default function(input) {
         return [];
       }
 
-      let prefixNode;
-      if(strPrefix.length) {
-        prefixNode = checkPrefix(trie, strPrefix).prefixNode;
-      } else {
-        prefixNode = trie;
-      }
+      const prefixNode = strPrefix.length ?
+        checkPrefix(trie, strPrefix).prefixNode
+        : trie;
 
       return recursePrefix(prefixNode, strPrefix, sorted);
     },

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import create from './create';
 import append from './append';
 import checkPrefix from './checkPrefix';
 import recursePrefix from './recursePrefix';
+import recurseRandomWord from './recurseRandomWord';
 import utils from './utils';
 import config from './config';
 import permutations from './permutations';
@@ -70,7 +71,7 @@ export default function(input) {
      * @returns Boolean
     */
     isPrefix(prefix) {
-      if(typeof prefix !== 'string' || prefix === '') {
+      if(typeof prefix !== 'string') {
         throw(`Expected string prefix, received ${typeof prefix}`);
       }
 
@@ -84,7 +85,7 @@ export default function(input) {
     * @returns Array
     */
     getPrefix(strPrefix, sorted = true) {
-      if(typeof strPrefix !== 'string' || strPrefix === '') {
+      if(typeof strPrefix !== 'string') {
         throw(`Expected string prefix, received ${typeof strPrefix}`);
       }
 
@@ -96,9 +97,32 @@ export default function(input) {
         return [];
       }
 
-      const { prefixNode } = checkPrefix(trie, strPrefix);
+      let prefixNode;
+      if(strPrefix.length) {
+        prefixNode = checkPrefix(trie, strPrefix).prefixNode;
+      } else {
+        prefixNode = trie;
+      }
 
       return recursePrefix(prefixNode, strPrefix, sorted);
+    },
+
+    /**
+    * Get a random word in the trie with the given prefix
+    * @returns Array
+    */
+    getRandomWordWithPrefix(strPrefix) {
+      if(typeof strPrefix !== 'string') {
+        throw(`Expected string prefix, received ${typeof strPrefix}`);
+      }
+
+      if(!this.isPrefix(strPrefix)) {
+        return '';
+      }
+
+      const { prefixNode } = checkPrefix(trie, strPrefix);
+
+      return recurseRandomWord(prefixNode, strPrefix);
     },
 
     /**
@@ -116,10 +140,7 @@ export default function(input) {
     * @returns Array
     */
     getWords(sorted = true) {
-      if(typeof sorted !== 'boolean') {
-        throw(`Expected sort parameter as boolean, received ${typeof sorted}`);
-      }
-      return recursePrefix(trie, '', sorted);
+      return this.getPrefix('', sorted);
     },
 
     /**

--- a/src/recurseRandomWord.js
+++ b/src/recurseRandomWord.js
@@ -1,0 +1,12 @@
+import config from './config';
+
+export default function recurseRandomWord(node, prefix) {
+  const word = prefix;
+
+  const branches = Object.keys(node);
+  const branch = branches[Math.floor(Math.random() * branches.length)];
+  if(branch === config.END_WORD) {
+    return word;
+  }
+  return recurseRandomWord(node[branch], prefix + branch);
+};

--- a/src/recurseRandomWord.js
+++ b/src/recurseRandomWord.js
@@ -2,9 +2,9 @@ import config from './config';
 
 export default function recurseRandomWord(node, prefix) {
   const word = prefix;
-
   const branches = Object.keys(node);
   const branch = branches[Math.floor(Math.random() * branches.length)];
+
   if(branch === config.END_WORD) {
     return word;
   }


### PR DESCRIPTION
Implements #5 

Taking advantage of the trie structure to quickly get random words.

Also relaxed the constraint that prefixes be non zero-length strings. This way, `getWords` and `getPrefix` can reuse the same backing implementation.