### PR TITLE
Add caseSensitive parameter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "node": 1
+    "node": 1,
+    "es6": true,
   },
   "parserOptions": {
     "ecmaVersion": 2017,

--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ import trie from 'trie-prefix-tree';
 Instantiate the Trie:
 
 ```javascript
+// create Trie
 var myTrie = trie(['cat', 'cats', 'dogs', 'elephant', 'tiger']);
+
+// create Trie with case-sensitive
+var myTrieWithCaseSensitive = trie(['cat', 'cats', 'dogs', 'elephant', 'tiger'], true);
 ```
 
 Trie functionality:

--- a/__tests__/create.js
+++ b/__tests__/create.js
@@ -4,7 +4,7 @@ describe('Creating the Trie', () => {
   it('throws when the first argument is not an array', () => {
     const input = '';
     const expected = `Expected parameter Array, received ${typeof input}`;
-    
+
     try {
       create(input);
     } catch(error) {
@@ -17,6 +17,22 @@ describe('Creating the Trie', () => {
     const data = create(input);
     const expected = {
       d: {
+        o: {
+          g: {
+            $: 1
+          }
+        }
+      }
+    };
+
+    expect(data).toEqual(expected);
+  });
+
+  it('returns a Trie object structure with case-sensitive', () => {
+    const input = ['Dog'];
+    const data = create(input, true);
+    const expected = {
+      D: {
         o: {
           g: {
             $: 1

--- a/__tests__/create.js
+++ b/__tests__/create.js
@@ -1,4 +1,5 @@
 import create from '../src/create';
+import utils from '../src/utils';
 
 describe('Creating the Trie', () => {
   it('throws when the first argument is not an array', () => {
@@ -14,8 +15,8 @@ describe('Creating the Trie', () => {
 
   it('returns a Trie object structure converted to lowercase', () => {
     const input = ['Dog'];
-    const data = create(input);
-    const expected = {
+    const data = utils.stringify(create(input), 0);
+    const expected = JSON.stringify({
       d: {
         o: {
           g: {
@@ -23,7 +24,7 @@ describe('Creating the Trie', () => {
           }
         }
       }
-    };
+    });
 
     expect(data).toEqual(expected);
   });

--- a/__tests__/hasWord.js
+++ b/__tests__/hasWord.js
@@ -1,7 +1,7 @@
 import trie from '../src/index';
 
 describe('validating a word exists', () => {
-  const input = ['dog', 'cat', 'lion', 'tiger', 'carse', 'car', 'scar'];
+  const input = ['dog', 'cat', 'lion', 'tiger', 'carse', 'car', 'scar', 'cute DOG'];
   const data = trie(input);
 
   it('throws an error when a word is not passed', () => {
@@ -12,8 +12,37 @@ describe('validating a word exists', () => {
     expect(data.hasWord('dog')).toEqual(true);
   });
 
+  it('returns true for a valid word found', () => {
+    expect(data.hasWord('cute dog')).toEqual(true);
+  });
+
   it('converts the word to lowercase', () => {
     expect(data.hasWord('DOG')).toEqual(true);
+  });
+
+  it('returns false for an invalid word', () => {
+    expect(data.hasWord('elephant')).toEqual(false);
+  });
+});
+
+describe('validating a word exists with case-sensitive', () => {
+  const input = ['dog', 'cat', 'lion', 'tiger', 'carse', 'car', 'scar', 'cute DOG'];
+  const data = trie(input, true);
+
+  it('throws an error when a word is not passed', () => {
+    expect(() => data.hasWord()).toThrow();
+  });
+
+  it('returns true for a valid word found', () => {
+    expect(data.hasWord('dog')).toEqual(true);
+  });
+
+  it('returns true for a valid word found', () => {
+    expect(data.hasWord('cute DOG')).toEqual(true);
+  });
+
+  it('returns false for a invalid word', () => {
+    expect(data.hasWord('cute dog')).toEqual(false);
   });
 
   it('returns false for an invalid word', () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,4 +1,5 @@
 import trie from '../src/index';
+import utils from '../src/utils';
 
 describe('Trie', () => {
   it('throws an error when the first argument specified is not an array', () => {
@@ -59,7 +60,7 @@ describe('Retrieving the Trie', () => {
 describe('Retrieving the RAW Trie tree', () => {
   it('returns the raw trie object structure', () => {
     const input = ['dog', 'dogs', 'donut'];
-    const actual = JSON.stringify(trie(input).tree());
+    const actual = utils.stringify(trie(input).tree(), 0);
     const expected = JSON.stringify({
       d: {
         o: {

--- a/src/append.js
+++ b/src/append.js
@@ -5,16 +5,16 @@ export default function append(trie, letter, index, array) {
   const isLastLetter = index === array.length - 1;
 
   if(isEndWordLetter && !isLastLetter) {
-    trie[config.END_WORD] = 1;
-    trie[config.END_WORD_REPLACER] = {};
-    trie = trie[config.END_WORD_REPLACER];
+    trie.set(config.END_WORD, 1);
+    trie.set(config.END_WORD_REPLACER, new Map());
+    trie = trie.get(config.END_WORD_REPLACER);
   } else {
-    trie[letter] = trie[letter] || {};
-    trie = trie[letter];
+    trie.set(letter, trie.get(letter) || new Map());
+    trie = trie.get(letter);
   }
 
   if(isLastLetter) {
-    trie[config.END_WORD] = 1;
+    trie.set(config.END_WORD, 1);
   }
 
   return trie;

--- a/src/checkPrefix.js
+++ b/src/checkPrefix.js
@@ -1,7 +1,9 @@
 import utils from './utils';
 
-export default function checkPrefix(prefixNode, prefix) {
-  const input = prefix.toLowerCase().split('');
+export default function checkPrefix(prefixNode, prefix, caseSensitive) {
+  const input = caseSensitive
+            ? prefix.split('')
+            : prefix.toLowerCase().split('');
   const prefixFound = input.every((letter, index) => {
     if(!prefixNode[letter]) {
       return false;

--- a/src/checkPrefix.js
+++ b/src/checkPrefix.js
@@ -3,10 +3,10 @@ import utils from './utils';
 export default function checkPrefix(prefixNode, prefix) {
   const input = prefix.toLowerCase().split('');
   const prefixFound = input.every((letter, index) => {
-    if(!prefixNode[letter]) {
+    if(!prefixNode.get(letter)) {
       return false;
     }
-    return prefixNode = prefixNode[letter];
+    return prefixNode = prefixNode.get(letter);
   });
 
   return {

--- a/src/create.js
+++ b/src/create.js
@@ -1,11 +1,17 @@
 import append from './append';
 
-export default function create(input) {
+export default function create(input, caseSensitive) {
   if(!Array.isArray(input)) {
     throw(`Expected parameter Array, received ${typeof input}`);
   }
 
   const trie = input.reduce((accumulator, item) => {
+    caseSensitive
+    ?
+    item
+      .split('')
+      .reduce(append, accumulator)
+    :
     item
       .toLowerCase()
       .split('')

--- a/src/create.js
+++ b/src/create.js
@@ -12,7 +12,7 @@ export default function create(input) {
       .reduce(append, accumulator);
 
     return accumulator;
-  }, {});
+  }, new Map());
 
   return trie;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ export default function(input) {
       const { prefixFound, prefixNode } = checkPrefix(trie, word);
 
       if(prefixFound) {
-        delete prefixNode[config.END_WORD];
+        prefixNode.delete(config.END_WORD);
       }
 
       return this;
@@ -152,7 +152,7 @@ export default function(input) {
       const { prefixFound, prefixNode } = checkPrefix(trie, word);
 
       if(prefixFound) {
-        return prefixNode[config.END_WORD] === 1;
+        return prefixNode.get(config.END_WORD) === 1;
       }
 
       return false;

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,12 @@ import permutations from './permutations';
 
 const PERMS_MIN_LEN = config.PERMS_MIN_LEN;
 
-export default function(input) {
+export default function(input, caseSensitive = false) {
   if(!Array.isArray(input)) {
     throw(`Expected parameter Array, received ${typeof input}`);
   }
 
-  const trie = create([...input]);
+  const trie = create([...input], caseSensitive);
 
   return {
     /**
@@ -23,7 +23,7 @@ export default function(input) {
     tree() {
       return trie;
     },
-    
+
     /**
      * Get a string representation of the trie
     */
@@ -43,7 +43,9 @@ export default function(input) {
         return append(...params);
       };
 
-      const input = word.toLowerCase().split('');
+      const input = caseSensitive
+            ? word.split('')
+            : word.toLowerCase().split('');
       input.reduce(reducer, trie);
 
       return this;
@@ -57,7 +59,8 @@ export default function(input) {
         throw(`Expected parameter string, received ${typeof word}`);
       }
 
-      const { prefixFound, prefixNode } = checkPrefix(trie, word);
+      const { prefixFound, prefixNode } =
+        checkPrefix(trie, word, caseSensitive);
 
       if(prefixFound) {
         delete prefixNode[config.END_WORD];
@@ -75,7 +78,7 @@ export default function(input) {
         throw(`Expected string prefix, received ${typeof prefix}`);
       }
 
-      const { prefixFound } = checkPrefix(trie, prefix);
+      const { prefixFound } = checkPrefix(trie, prefix, caseSensitive);
 
       return prefixFound;
     },
@@ -98,7 +101,7 @@ export default function(input) {
       }
 
       const prefixNode = strPrefix.length ?
-        checkPrefix(trie, strPrefix).prefixNode
+        checkPrefix(trie, strPrefix, caseSensitive).prefixNode
         : trie;
 
       return recursePrefix(prefixNode, strPrefix, sorted);
@@ -117,7 +120,7 @@ export default function(input) {
         return '';
       }
 
-      const { prefixNode } = checkPrefix(trie, strPrefix);
+      const { prefixNode } = checkPrefix(trie, strPrefix, caseSensitive);
 
       return recurseRandomWord(prefixNode, strPrefix);
     },
@@ -149,7 +152,8 @@ export default function(input) {
         throw(`Expected string word, received ${typeof word}`);
       }
 
-      const { prefixFound, prefixNode } = checkPrefix(trie, word);
+      const { prefixFound, prefixNode } =
+        checkPrefix(trie, word, caseSensitive);
 
       if(prefixFound) {
         return prefixNode[config.END_WORD] === 1;

--- a/src/permutations.js
+++ b/src/permutations.js
@@ -10,9 +10,10 @@ export default function permutations(letters, trie, opts = {
   const words = [];
 
   const permute = (word, node, prefix = '') => {
+    if(!(node instanceof Map)) return words.sort();
     const wordIsEmpty = word.length === 0;
     const wordFound = words.includes(prefix);
-    const endWordFound = node[config.END_WORD] === 1;
+    const endWordFound = node.get(config.END_WORD) === 1;
 
     if(wordIsEmpty && endWordFound && !wordFound) {
       words.push(prefix);
@@ -27,9 +28,9 @@ export default function permutations(letters, trie, opts = {
         }
       }
 
-      if(node[letter]) {
+      if(node.get(letter)) {
         const remaining = word.substring(0, i) + word.substring(i + 1, len);
-        permute(remaining, node[letter], prefix + letter, words);
+        permute(remaining, node.get(letter), prefix + letter, words);
       }
     }
 

--- a/src/recursePrefix.js
+++ b/src/recursePrefix.js
@@ -20,9 +20,9 @@ const pushInOrder = function(word, prefixes) {
 export default function recursePrefix(node, prefix, sorted, prefixes = []) {
   let word = prefix;
 
-  for(const branch in node) {
+  for(const branch of node.keys()) {
     let currentLetter = branch;
-    if(branch === config.END_WORD && typeof node[branch] === 'number') {
+    if(branch === config.END_WORD && typeof node.get(branch) === 'number') {
       if(sorted) {
         pushInOrder(word, prefixes);
       } else {
@@ -32,7 +32,9 @@ export default function recursePrefix(node, prefix, sorted, prefixes = []) {
     } else if(branch === config.END_WORD_REPLACER) {
       currentLetter = config.END_WORD;
     }
-    recursePrefix(node[branch], prefix + currentLetter, sorted, prefixes);
+    if(node.get(branch) instanceof Map) {
+      recursePrefix(node.get(branch), prefix + currentLetter, sorted, prefixes);
+    }
   }
 
   return prefixes;

--- a/src/recurseRandomWord.js
+++ b/src/recurseRandomWord.js
@@ -2,11 +2,11 @@ import config from './config';
 
 export default function recurseRandomWord(node, prefix) {
   const word = prefix;
-  const branches = Object.keys(node);
+  const branches = [...node.keys()];
   const branch = branches[Math.floor(Math.random() * branches.length)];
 
-  if(branch === config.END_WORD) {
+  if(branch === config.END_WORD || !node.get(branch)) {
     return word;
   }
-  return recurseRandomWord(node[branch], prefix + branch);
+  return recurseRandomWord(node.get(branch), prefix + branch);
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,10 +6,20 @@ export default {
     return JSON.parse(JSON.stringify(obj));
   },
 
+  mapToObj(map) {
+    const obj = {};
+    for(const [k, v] of map) {
+      obj[k] = (v instanceof Map) ? this.mapToObj(v) : v;
+    }
+    return obj;
+  },
+
   stringify(obj, spacer = 2) {
     if(typeof obj === 'undefined') {
       return '';
     }
-    return JSON.stringify(obj, null, spacer);
+    return (obj instanceof Map)
+          ? JSON.stringify(this.mapToObj(obj), null, spacer)
+          : JSON.stringify(obj, null, spacer);
   },
 };


### PR DESCRIPTION
Thanks for this useful module!!

In my use case, I have to treat the words with case-sensitive, and I realized the trie would convert the word to lowercase no matter what. So I added a parameter called `caseSensitive`  with default value `false` to fit your original design.

I publish a temporary npm module called `trie-prefix-tree-v1.6`. Try the example below!
```js
const trie = require('trie-prefix-tree');
const trieWithCaseSensitive = require('trie-prefix-tree-v1.6');

const words = ['abc DEF', 'ABC DEF'];
const input = trie(words);
const inputWithCaseSensitive = trieWithCaseSensitive(words, true);

console.log(`getPrefix of 'a' from input: ${input.getPrefix('a')}`);
console.log(`getPrefix of 'a' from inputWithCaseSensitive: ${inputWithCaseSensitive.getPrefix('a')}`);
/*
getPrefix of 'a' from input: abc def
getPrefix of 'a' from inputWithCaseSensitive: abc DEF
*/
```