### PR TITLE
Convert Dictionary to Map for stable data input order

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "node": 1
+    "node": 1,
+    "es6": true,
   },
   "parserOptions": {
     "ecmaVersion": 2017,

--- a/__tests__/create.js
+++ b/__tests__/create.js
@@ -1,4 +1,5 @@
 import create from '../src/create';
+import utils from '../src/utils';
 
 describe('Creating the Trie', () => {
   it('throws when the first argument is not an array', () => {
@@ -14,8 +15,8 @@ describe('Creating the Trie', () => {
 
   it('returns a Trie object structure converted to lowercase', () => {
     const input = ['Dog'];
-    const data = create(input);
-    const expected = {
+    const data = utils.stringify(create(input), 0);
+    const expected = JSON.stringify({
       d: {
         o: {
           g: {
@@ -23,7 +24,7 @@ describe('Creating the Trie', () => {
           }
         }
       }
-    };
+    });
 
     expect(data).toEqual(expected);
   });

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,4 +1,5 @@
 import trie from '../src/index';
+import utils from '../src/utils';
 
 describe('Trie', () => {
   it('throws an error when the first argument specified is not an array', () => {
@@ -59,7 +60,7 @@ describe('Retrieving the Trie', () => {
 describe('Retrieving the RAW Trie tree', () => {
   it('returns the raw trie object structure', () => {
     const input = ['dog', 'dogs', 'donut'];
-    const actual = JSON.stringify(trie(input).tree());
+    const actual = utils.stringify(trie(input).tree(), 0);
     const expected = JSON.stringify({
       d: {
         o: {

--- a/src/append.js
+++ b/src/append.js
@@ -5,16 +5,16 @@ export default function append(trie, letter, index, array) {
   const isLastLetter = index === array.length - 1;
 
   if(isEndWordLetter && !isLastLetter) {
-    trie[config.END_WORD] = 1;
-    trie[config.END_WORD_REPLACER] = {};
-    trie = trie[config.END_WORD_REPLACER];
+    trie.set(config.END_WORD, 1);
+    trie.set(config.END_WORD_REPLACER, new Map());
+    trie = trie.get(config.END_WORD_REPLACER);
   } else {
-    trie[letter] = trie[letter] || {};
-    trie = trie[letter];
+    trie.set(letter, trie.get(letter) || new Map());
+    trie = trie.get(letter);
   }
 
   if(isLastLetter) {
-    trie[config.END_WORD] = 1;
+    trie.set(config.END_WORD, 1);
   }
 
   return trie;

--- a/src/checkPrefix.js
+++ b/src/checkPrefix.js
@@ -3,10 +3,10 @@ import utils from './utils';
 export default function checkPrefix(prefixNode, prefix) {
   const input = prefix.toLowerCase().split('');
   const prefixFound = input.every((letter, index) => {
-    if(!prefixNode[letter]) {
+    if(!prefixNode.get(letter)) {
       return false;
     }
-    return prefixNode = prefixNode[letter];
+    return prefixNode = prefixNode.get(letter);
   });
 
   return {

--- a/src/create.js
+++ b/src/create.js
@@ -12,7 +12,7 @@ export default function create(input) {
       .reduce(append, accumulator);
 
     return accumulator;
-  }, {});
+  }, new Map());
 
   return trie;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ export default function(input) {
       const { prefixFound, prefixNode } = checkPrefix(trie, word);
 
       if(prefixFound) {
-        delete prefixNode[config.END_WORD];
+        prefixNode.delete(config.END_WORD);
       }
 
       return this;
@@ -152,7 +152,7 @@ export default function(input) {
       const { prefixFound, prefixNode } = checkPrefix(trie, word);
 
       if(prefixFound) {
-        return prefixNode[config.END_WORD] === 1;
+        return prefixNode.get(config.END_WORD) === 1;
       }
 
       return false;

--- a/src/permutations.js
+++ b/src/permutations.js
@@ -10,9 +10,10 @@ export default function permutations(letters, trie, opts = {
   const words = [];
 
   const permute = (word, node, prefix = '') => {
+    if(!(node instanceof Map)) return words.sort();
     const wordIsEmpty = word.length === 0;
     const wordFound = words.includes(prefix);
-    const endWordFound = node[config.END_WORD] === 1;
+    const endWordFound = node.get(config.END_WORD) === 1;
 
     if(wordIsEmpty && endWordFound && !wordFound) {
       words.push(prefix);
@@ -27,9 +28,9 @@ export default function permutations(letters, trie, opts = {
         }
       }
 
-      if(node[letter]) {
+      if(node.get(letter)) {
         const remaining = word.substring(0, i) + word.substring(i + 1, len);
-        permute(remaining, node[letter], prefix + letter, words);
+        permute(remaining, node.get(letter), prefix + letter, words);
       }
     }
 

--- a/src/recursePrefix.js
+++ b/src/recursePrefix.js
@@ -20,9 +20,9 @@ const pushInOrder = function(word, prefixes) {
 export default function recursePrefix(node, prefix, sorted, prefixes = []) {
   let word = prefix;
 
-  for(const branch in node) {
+  for(const branch of node.keys()) {
     let currentLetter = branch;
-    if(branch === config.END_WORD && typeof node[branch] === 'number') {
+    if(branch === config.END_WORD && typeof node.get(branch) === 'number') {
       if(sorted) {
         pushInOrder(word, prefixes);
       } else {
@@ -32,7 +32,9 @@ export default function recursePrefix(node, prefix, sorted, prefixes = []) {
     } else if(branch === config.END_WORD_REPLACER) {
       currentLetter = config.END_WORD;
     }
-    recursePrefix(node[branch], prefix + currentLetter, sorted, prefixes);
+    if(node.get(branch) instanceof Map) {
+      recursePrefix(node.get(branch), prefix + currentLetter, sorted, prefixes);
+    }
   }
 
   return prefixes;

--- a/src/recurseRandomWord.js
+++ b/src/recurseRandomWord.js
@@ -2,11 +2,11 @@ import config from './config';
 
 export default function recurseRandomWord(node, prefix) {
   const word = prefix;
-  const branches = Object.keys(node);
+  const branches = [...node.keys()];
   const branch = branches[Math.floor(Math.random() * branches.length)];
 
-  if(branch === config.END_WORD) {
+  if(branch === config.END_WORD || !node.get(branch)) {
     return word;
   }
-  return recurseRandomWord(node[branch], prefix + branch);
+  return recurseRandomWord(node.get(branch), prefix + branch);
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,10 +6,20 @@ export default {
     return JSON.parse(JSON.stringify(obj));
   },
 
+  mapToObj(map) {
+    const obj = {};
+    for(const [k, v] of map) {
+      obj[k] = (v instanceof Map) ? this.mapToObj(v) : v;
+    }
+    return obj;
+  },
+
   stringify(obj, spacer = 2) {
     if(typeof obj === 'undefined') {
       return '';
     }
-    return JSON.stringify(obj, null, spacer);
+    return (obj instanceof Map)
+          ? JSON.stringify(this.mapToObj(obj), null, spacer)
+          : JSON.stringify(obj, null, spacer);
   },
 };


### PR DESCRIPTION
In this use case, given a sorted array of words, and invoke getPrefix(x, false) with disable sort. For `Alphabetical characters`, it works like a charm, but for `Arabic characters`, it gets non-stable results. So I implemented a version of Map instead of Dictionary for stable data input order.

I publish a temporary npm module called `trie-prefix-tree-v1.7`. Try the example below!
- `Alphabetical characters`
```js
const trie = require('trie-prefix-tree');
const trieWithMap = require('trie-prefix-tree-v1.7');

const words = ['ad', 'ab', 'ac', 'aa'];
const input = trie(words);
const inputWithMap = trieWithMap(words);

console.log(`getPrefix of 'a' from input with sort: ${JSON.stringify(input.getPrefix('a'))}`);
console.log(`getPrefix of 'a' from input: ${JSON.stringify(input.getPrefix('a', false))}`);
console.log(`getPrefix of 'a' from inputWithMap with sort: ${JSON.stringify(inputWithMap.getPrefix('a'))}`);
console.log(`getPrefix of 'a' from inputWithMap: ${JSON.stringify(inputWithMap.getPrefix('a', false))}`);
/*
getPrefix of 'a' from input with sort: ["aa","ab","ac","ad"]
getPrefix of 'a' from input: ["ad","ab","ac","aa"]
getPrefix of 'a' from inputWithMap with sort: ["aa","ab","ac","ad"]
getPrefix of 'a' from inputWithMap: ["ad","ab","ac","aa"]
*/
```

- `Arabic characters`
```js
const trie = require('trie-prefix-tree');
const trieWithMap = require('trie-prefix-tree-v1.7');

const words = ['a4', 'a2', 'a3', 'a1'];
const input = trie(words);
const inputWithMap = trieWithMap(words);

console.log(`getPrefix of 'a' from input with sort: ${JSON.stringify(input.getPrefix('a'))}`);
console.log(`getPrefix of 'a' from input: ${JSON.stringify(input.getPrefix('a', false))}`);
console.log(`getPrefix of 'a' from inputWithMap with sort: ${JSON.stringify(inputWithMap.getPrefix('a'))}`);
console.log(`getPrefix of 'a' from inputWithMap: ${JSON.stringify(inputWithMap.getPrefix('a', false))}`);
/*
getPrefix of 'a' from input with sort: ["a1","a2","a3","a4"]
getPrefix of 'a' from input: ["a1","a2","a3","a4"]
getPrefix of 'a' from inputWithMap with sort: ["a1","a2","a3","a4"]
getPrefix of 'a' from inputWithMap: ["a4","a2","a3","a1"]
*/
```