### PR TITLE
Add caseSensitive parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ import trie from 'trie-prefix-tree';
 Instantiate the Trie:
 
 ```javascript
+// create Trie
 var myTrie = trie(['cat', 'cats', 'dogs', 'elephant', 'tiger']);
+
+// create Trie with case-sensitive
+var myTrieWithCaseSensitive = trie(['cat', 'cats', 'dogs', 'elephant', 'tiger'], true);
 ```
 
 Trie functionality:

--- a/__tests__/create.js
+++ b/__tests__/create.js
@@ -4,7 +4,7 @@ describe('Creating the Trie', () => {
   it('throws when the first argument is not an array', () => {
     const input = '';
     const expected = `Expected parameter Array, received ${typeof input}`;
-    
+
     try {
       create(input);
     } catch(error) {
@@ -17,6 +17,22 @@ describe('Creating the Trie', () => {
     const data = create(input);
     const expected = {
       d: {
+        o: {
+          g: {
+            $: 1
+          }
+        }
+      }
+    };
+
+    expect(data).toEqual(expected);
+  });
+
+  it('returns a Trie object structure with case-sensitive', () => {
+    const input = ['Dog'];
+    const data = create(input, true);
+    const expected = {
+      D: {
         o: {
           g: {
             $: 1

--- a/__tests__/hasWord.js
+++ b/__tests__/hasWord.js
@@ -1,7 +1,7 @@
 import trie from '../src/index';
 
 describe('validating a word exists', () => {
-  const input = ['dog', 'cat', 'lion', 'tiger', 'carse', 'car', 'scar'];
+  const input = ['dog', 'cat', 'lion', 'tiger', 'carse', 'car', 'scar', 'cute DOG'];
   const data = trie(input);
 
   it('throws an error when a word is not passed', () => {
@@ -12,8 +12,37 @@ describe('validating a word exists', () => {
     expect(data.hasWord('dog')).toEqual(true);
   });
 
+  it('returns true for a valid word found', () => {
+    expect(data.hasWord('cute dog')).toEqual(true);
+  });
+
   it('converts the word to lowercase', () => {
     expect(data.hasWord('DOG')).toEqual(true);
+  });
+
+  it('returns false for an invalid word', () => {
+    expect(data.hasWord('elephant')).toEqual(false);
+  });
+});
+
+describe('validating a word exists with case-sensitive', () => {
+  const input = ['dog', 'cat', 'lion', 'tiger', 'carse', 'car', 'scar', 'cute DOG'];
+  const data = trie(input, true);
+
+  it('throws an error when a word is not passed', () => {
+    expect(() => data.hasWord()).toThrow();
+  });
+
+  it('returns true for a valid word found', () => {
+    expect(data.hasWord('dog')).toEqual(true);
+  });
+
+  it('returns true for a valid word found', () => {
+    expect(data.hasWord('cute DOG')).toEqual(true);
+  });
+
+  it('returns false for a invalid word', () => {
+    expect(data.hasWord('cute dog')).toEqual(false);
   });
 
   it('returns false for an invalid word', () => {

--- a/src/checkPrefix.js
+++ b/src/checkPrefix.js
@@ -1,7 +1,9 @@
 import utils from './utils';
 
-export default function checkPrefix(prefixNode, prefix) {
-  const input = prefix.toLowerCase().split('');
+export default function checkPrefix(prefixNode, prefix, caseSensitive) {
+  const input = caseSensitive
+            ? prefix.split('')
+            : prefix.toLowerCase().split('');
   const prefixFound = input.every((letter, index) => {
     if(!prefixNode[letter]) {
       return false;

--- a/src/create.js
+++ b/src/create.js
@@ -1,11 +1,17 @@
 import append from './append';
 
-export default function create(input) {
+export default function create(input, caseSensitive) {
   if(!Array.isArray(input)) {
     throw(`Expected parameter Array, received ${typeof input}`);
   }
 
   const trie = input.reduce((accumulator, item) => {
+    caseSensitive
+    ?
+    item
+      .split('')
+      .reduce(append, accumulator)
+    :
     item
       .toLowerCase()
       .split('')

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,12 @@ import permutations from './permutations';
 
 const PERMS_MIN_LEN = config.PERMS_MIN_LEN;
 
-export default function(input) {
+export default function(input, caseSensitive = false) {
   if(!Array.isArray(input)) {
     throw(`Expected parameter Array, received ${typeof input}`);
   }
 
-  const trie = create([...input]);
+  const trie = create([...input], caseSensitive);
 
   return {
     /**
@@ -23,7 +23,7 @@ export default function(input) {
     tree() {
       return trie;
     },
-    
+
     /**
      * Get a string representation of the trie
     */
@@ -43,7 +43,9 @@ export default function(input) {
         return append(...params);
       };
 
-      const input = word.toLowerCase().split('');
+      const input = caseSensitive
+            ? word.split('')
+            : word.toLowerCase().split('');
       input.reduce(reducer, trie);
 
       return this;
@@ -57,7 +59,8 @@ export default function(input) {
         throw(`Expected parameter string, received ${typeof word}`);
       }
 
-      const { prefixFound, prefixNode } = checkPrefix(trie, word);
+      const { prefixFound, prefixNode } =
+        checkPrefix(trie, word, caseSensitive);
 
       if(prefixFound) {
         delete prefixNode[config.END_WORD];
@@ -75,7 +78,7 @@ export default function(input) {
         throw(`Expected string prefix, received ${typeof prefix}`);
       }
 
-      const { prefixFound } = checkPrefix(trie, prefix);
+      const { prefixFound } = checkPrefix(trie, prefix, caseSensitive);
 
       return prefixFound;
     },
@@ -98,7 +101,7 @@ export default function(input) {
       }
 
       const prefixNode = strPrefix.length ?
-        checkPrefix(trie, strPrefix).prefixNode
+        checkPrefix(trie, strPrefix, caseSensitive).prefixNode
         : trie;
 
       return recursePrefix(prefixNode, strPrefix, sorted);
@@ -117,7 +120,7 @@ export default function(input) {
         return '';
       }
 
-      const { prefixNode } = checkPrefix(trie, strPrefix);
+      const { prefixNode } = checkPrefix(trie, strPrefix, caseSensitive);
 
       return recurseRandomWord(prefixNode, strPrefix);
     },
@@ -149,7 +152,8 @@ export default function(input) {
         throw(`Expected string word, received ${typeof word}`);
       }
 
-      const { prefixFound, prefixNode } = checkPrefix(trie, word);
+      const { prefixFound, prefixNode } =
+        checkPrefix(trie, word, caseSensitive);
 
       if(prefixFound) {
         return prefixNode[config.END_WORD] === 1;


### PR DESCRIPTION
Thanks for this useful module!!

In my use case, I have to treat the words with case-sensitive, and I realized the trie would convert the word to lowercase no matter what. So I added a parameter called `caseSensitive`  with default value `false` to fit your original design.

I publish a temporary npm module called `trie-prefix-tree-v1.6`. Try the example below!
```js
const trie = require('trie-prefix-tree');
const trieWithCaseSensitive = require('trie-prefix-tree-v1.6');

const words = ['abc DEF', 'ABC DEF'];
const input = trie(words);
const inputWithCaseSensitive = trieWithCaseSensitive(words, true);

console.log(`getPrefix of 'a' from input: ${input.getPrefix('a')}`);
console.log(`getPrefix of 'a' from inputWithCaseSensitive: ${inputWithCaseSensitive.getPrefix('a')}`);
/*
getPrefix of 'a' from input: abc def
getPrefix of 'a' from inputWithCaseSensitive: abc DEF
*/
```